### PR TITLE
Set up Travis CI to run the tests

### DIFF
--- a/.travis-ci-apache
+++ b/.travis-ci-apache
@@ -1,0 +1,9 @@
+<VirtualHost *:80>
+  DocumentRoot %TRAVIS_BUILD_DIR%
+  <IfModule mod_fastcgi.c>
+    AddHandler php5-fcgi .php
+    Action php5-fcgi /php5-fcgi
+    Alias /php5-fcgi /usr/lib/cgi-bin/php5-fcgi
+    FastCgiExternalServer /usr/lib/cgi-bin/php5-fcgi -host 127.0.0.1:9000 -pass-header Authorization
+  </IfModule>
+</VirtualHost>

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+install:
+  - composer install
+
+before_script:
+  - sudo apt-get update
+  - sudo apt-get install apache2 libapache2-mod-fastcgi
+  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.d/www.conf; fi
+  - sudo cp ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf.default ~/.phpenv/versions/$(phpenv version-name)/etc/php-fpm.conf
+  - sudo a2enmod actions fastcgi alias
+  - ~/.phpenv/versions/$(phpenv version-name)/sbin/php-fpm
+  - sudo cp -f .travis-ci-apache /etc/apache2/sites-available/default
+  - sudo sed -e "s?%TRAVIS_BUILD_DIR%?$(pwd)?g" --in-place /etc/apache2/sites-available/default
+  - sudo service apache2 restart
+
+script: test_result="$(curl -s http://localhost/tests/)" && echo "$test_result" && echo "$test_result" | grep -q 'ALL TESTS PASSED' || exit 1


### PR DESCRIPTION
To help spotting issues between PHP versions I propose to set up Travis to run the tests.

Tests do not pass on PHP 5.x due to #10 and #11.

You can see it running on my fork: https://travis-ci.org/LeSuisse/PHP-Cookie